### PR TITLE
Release of the new version 1.0.8_exp_build_01082025 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,7 +76,7 @@ MS5611 Library Mike Refactored Version 1.0.4_exp_build_29072025 | 29 Jun 2025
 - `getPROM()` — Access to PROM calibration coefficients.
 - `getCRC()` — Computes and returns CRC from PROM.
 - Automatic correction for anomalous pressure values.
-- Added multiple example sketches.
+- Added multiple example sketches to illustrate advanced usage.
 
 ---
 

--- a/library.json
+++ b/library.json
@@ -9,7 +9,7 @@
   "authors": {
     "name": "Francis Mike John Camogao"
   },
-  "version": "1.0.4_exp_build_29072025",
+  "version": "1.0.8_exp_build_01082025",
   "frameworks": "arduino",
   "platforms": "*"
 }

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=MS5611 Mike Refactored
-version=1.0.4_exp_build_29072025
+version=1.0.8_exp_build_01082025
 author=Francis Mike John Camogao
 maintainer=Francis Mike John Camogao 
 sentence=Refactored and Enhanced version of the MS5611 Pressure & Temperature Sensor Arduino Library.

--- a/src/derivative_estimator.h
+++ b/src/derivative_estimator.h
@@ -1,0 +1,61 @@
+/*
+
+___  ___ _____ _____  ____  __   __   ___  ____ _         ______      __           _                     _ 
+|  \/  |/  ___|  ___|/ ___|/  | /  |  |  \/  (_) |        | ___ \    / _|         | |                   | |
+| .  . |\ `--.|___ \/ /___ `| | `| |  | .  . |_| | _____  | |_/ /___| |_ __ _  ___| |_ ___  _ __ ___  __| |
+| |\/| | `--. \   \ \ ___ \ | |  | |  | |\/| | | |/ / _ \ |    // _ \  _/ _` |/ __| __/ _ \| '__/ _ \/ _` |
+| |  | |/\__/ /\__/ / \_/ |_| |__| |_ | |  | | |   <  __/ | |\ \  __/ || (_| | (__| || (_) | | |  __/ (_| |
+\_|  |_/\____/\____/\_____/\___/\___/ \_|  |_/_|_|\_\___| \_| \_\___|_| \__,_|\___|\__\___/|_|  \___|\__,_|
+                              LIBRARY VERSION: 1.0.8_exp_build_01082025  
+
+    Copyright (c) 2025 Francis Mike John Camogao
+    Released under MIT License - see LICENSE file for details.
+    GIT: https://github.com/mikeedudee/MS5611-Mike-Refactored.git
+
+*/
+
+#ifndef DERIVATIVE_ESTIMATOR_H
+#define DERIVATIVE_ESTIMATOR_H
+
+#include <Arduino.h>  // for micros()
+
+/// Simple first‐order derivative estimator (for velocity or acceleration)
+class DerivativeEstimator {
+public:
+    DerivativeEstimator() : _initialized(false), _lastTime(0.0f), _lastValue(0.0f) {}
+
+    float update(float value, float time) {
+        if (!_initialized) {
+            _initialized = true;
+            _lastTime    = time;
+            _lastValue   = value;
+
+            return 0.0f;
+        }
+
+        // Ensure time is monotonic and greater than last recorded time
+        float dt = time - _lastTime;
+        
+        if (dt <= 0.0f) {
+            return 0.0f;  // Protect against non-monotonic or zero interval
+        }
+
+        float derivative    = (value - _lastValue) / dt;
+        _lastTime           = time;
+        _lastValue          = value;
+
+        return derivative;
+    }
+
+    /// Reset the estimator to its uninitialized state
+    void reset() {
+        _initialized = false;
+    }
+
+private:
+    bool    _initialized;
+    float   _lastTime;
+    float   _lastValue;
+};
+
+#endif  // DERIVATIVE_ESTIMATOR_H

--- a/src/filters/kalman_filter.h
+++ b/src/filters/kalman_filter.h
@@ -1,0 +1,77 @@
+/*
+
+    Credit to Denys Sene, January, 1, 2017. I mostly just reused and refactored his 
+    code specifically the filter estimation algorithm.
+___  ___ _____ _____  ____  __   __   ___  ____ _         ______      __           _                     _ 
+|  \/  |/  ___|  ___|/ ___|/  | /  |  |  \/  (_) |        | ___ \    / _|         | |                   | |
+| .  . |\ `--.|___ \/ /___ `| | `| |  | .  . |_| | _____  | |_/ /___| |_ __ _  ___| |_ ___  _ __ ___  __| |
+| |\/| | `--. \   \ \ ___ \ | |  | |  | |\/| | | |/ / _ \ |    // _ \  _/ _` |/ __| __/ _ \| '__/ _ \/ _` |
+| |  | |/\__/ /\__/ / \_/ |_| |__| |_ | |  | | |   <  __/ | |\ \  __/ || (_| | (__| || (_) | | |  __/ (_| |
+\_|  |_/\____/\____/\_____/\___/\___/ \_|  |_/_|_|\_\___| \_| \_\___|_| \__,_|\___|\__\___/|_|  \___|\__,_|
+                              LIBRARY VERSION: 1.0.8_exp_build_01082025  
+
+    Copyright (c) 2025 Francis Mike John Camogao
+    Released under MIT License - see LICENSE file for details.
+    GIT: https://github.com/mikeedudee/MS5611-Mike-Refactored.git
+
+*/
+
+#ifndef KALMAN_FILTER_H
+#define KALMAN_FILTER_H
+
+#include <stdint.h>
+#include <math.h>
+
+class KalmanFilter {
+    public:
+        // Constructor with default uncertainties
+        // e_mea: measurement uncertainty (>0)
+        // e_est: estimation uncertainty (≥0)
+        // q    : process noise (≥0)
+        explicit KalmanFilter(float e_mea = 1.0f,
+                              float e_est = 1.0f,
+                              float q_    = 0.01f)
+            :   _err_measure(e_mea),
+                _err_estimate(e_est),
+                _q(q_)
+            { }
+
+            // Set filter parameters at runtime
+            bool setParameters(float e_mea, float e_est, float q) {
+                if (e_mea <= 0.0f || e_est < 0.0f || q < 0.0f) {
+                    return false;
+                }
+
+                _err_measure  = e_mea;
+                _err_estimate = e_est;
+                _q            = q;
+
+                // (Re-initialize state if desired)
+                _last_estimate    = 0.0f;
+                _current_estimate = 0.0f;
+                _kalman_gain      = 0.0f;
+
+                return true;
+            }
+
+            // Update filter with a new measurement
+            // Returns the filtered estimate
+            float update(float measurement) {
+                _kalman_gain        = _err_estimate / (_err_estimate + _err_measure);
+                _current_estimate   = _last_estimate + _kalman_gain * (measurement - _last_estimate);
+                _err_estimate       = (1.0f - _kalman_gain) * _err_estimate + fabsf(_last_estimate - _current_estimate) * _q;
+                _last_estimate      = _current_estimate;
+
+                return _current_estimate;
+            }
+
+    private:
+        float _err_measure;
+        float _err_estimate;
+        float _q;
+        float _current_estimate = 0;
+        float _last_estimate    = 0;
+        float _kalman_gain      = 0;
+};
+
+#endif 

--- a/src/filters/median_filter.h
+++ b/src/filters/median_filter.h
@@ -1,0 +1,94 @@
+/*
+___  ___ _____ _____  ____  __   __   ___  ____ _         ______      __           _                     _ 
+|  \/  |/  ___|  ___|/ ___|/  | /  |  |  \/  (_) |        | ___ \    / _|         | |                   | |
+| .  . |\ `--.|___ \/ /___ `| | `| |  | .  . |_| | _____  | |_/ /___| |_ __ _  ___| |_ ___  _ __ ___  __| |
+| |\/| | `--. \   \ \ ___ \ | |  | |  | |\/| | | |/ / _ \ |    // _ \  _/ _` |/ __| __/ _ \| '__/ _ \/ _` |
+| |  | |/\__/ /\__/ / \_/ |_| |__| |_ | |  | | |   <  __/ | |\ \  __/ || (_| | (__| || (_) | | |  __/ (_| |
+\_|  |_/\____/\____/\_____/\___/\___/ \_|  |_/_|_|\_\___| \_| \_\___|_| \__,_|\___|\__\___/|_|  \___|\__,_|
+                              LIBRARY VERSION: 1.0.8_exp_build_01082025  
+
+    Copyright (c) 2025 Francis Mike John Camogao
+    Released under MIT License - see LICENSE file for details.
+    GIT: https://github.com/mikeedudee/MS5611-Mike-Refactored.git
+
+*/
+
+#ifndef MEDIAN_FILTER_H
+#define MEDIAN_FILTER_H
+
+#include <stdint.h>
+
+// A fixed‐maximum median filter with runtime window‐size control
+class MedianFilter {
+    public:
+        // Maximum allowed window size (must be odd)
+        static constexpr uint8_t MAX_WINDOW = 21u;
+        
+        // Constructor: default window size = 5
+        explicit MedianFilter(uint8_t ws = 5u) 
+        : windowSize_(0), idx_(0), count_(0) 
+        {
+            static_assert((MAX_WINDOW % 2u) == 1u, "MAX_WINDOW must be odd");
+            setWindowSize(ws);
+        }
+
+        // Set the window size at runtime (must be 1 ≤ ws ≤ MAX_WINDOW, odd)
+        // Returns true if successful
+        bool setWindowSize(uint8_t ws) {
+            if (ws == 0u || ws > MAX_WINDOW || (ws % 2u) == 0u) {
+                return false;
+            }
+
+            windowSize_ = ws;
+            idx_        = 0u;
+            count_      = 0u;
+
+            // Zero‐initialize buffer
+            for (uint8_t i = 0u; i < MAX_WINDOW; ++i) {
+                buffer_[i] = 0.0f;
+            }
+
+            return true;
+        }
+
+        // Feed a new sample; returns the median of the last windowSize_ samples
+        float update(float sample) {
+            // Insert into circular buffer
+            buffer_[idx_]   = sample;
+            idx_            = (idx_ + 1u) % windowSize_;
+
+            if (count_ < windowSize_) {
+                ++count_;
+            }
+
+            // Copy valid samples into temp
+            float temp[MAX_WINDOW];
+
+            for (uint8_t i = 0u; i < count_; ++i) {
+                temp[i] = buffer_[i];
+            }
+
+            // Insertion‐sort first count_ elements
+            for (uint8_t i = 1u; i < count_; ++i) {
+                float   key = temp[i];
+                int8_t  j   = i - 1;
+                
+                while (j >= 0 && temp[j] > key) {
+                    temp[j + 1u] = temp[j];
+                    --j;
+                }
+
+                temp[uint8_t(j + 1u)] = key;
+            }
+            // Return middle element
+            return temp[count_ / 2u];
+        }
+
+    private:
+        uint8_t windowSize_;
+        uint8_t idx_;
+        uint8_t count_;
+        float   buffer_[MAX_WINDOW];
+};
+
+#endif  // MEDIAN_FILTER_H


### PR DESCRIPTION
FIXES:
- blank variable pointers that goes nowhere in the memory or simply does not have use.
- General Bug fixes

ADDITION:
Added simultaneous calculation for performance
Added getLastRead -  Get timestamp of the last read operation
Added getResult() - Get result of the last operation (0 = success, non-zero = error)
Added SimpleKalmanFilter - 
Added Median Filter - Sorts a small window (odd N) of readings and takes the middle value—great for rejecting spikes.
Added vertical velocity and acceleration algorithm
Added Author description: AUTHOR
Added Library URL: LIBRARY_URL
Added Library Name: LIBRARY_NAME
Added Library description: LIBRARY_DESCRIPTION
Added Library Version: MS5611_LIB_VERSION

API Calls:
enableMedianFilter() - use Median Filter
enableKalmanFilter() - use Kalman Filter
medianFilter() - use median filter for altitude
kalmanFilter() - use kalman filter for altitude
resetDynamics() - (Optional) reset the velocity and acceleration computation if you reconfigure filters mid-flight
getVelocity() - calculate velocity from the specific input
getAcceleration() - calculate acceleration from the specific input
spikeDetection() - detector of spike in reading
getLastRead() - timestamp of the last read operation [debugging only (dev-mode)]
getResult() - Get result of the last operation (0 = success, non-zero = error) [debugging only (dev-mode)]


# PERFORMANCE MODE
getTemperature() - Manual call of performance version of getting temperature
getPressure() - Manual call of performance version of getting pressure
** Can also be called using performanceRead() with "auto" as numeric data type, example usage: 

auto performanceRead   = ms5611.performanceRead();
Serial.print("T = "); Serial.print(performanceRead.temperature, 2);
Serial.print(" °C   P = "); Serial.print(performanceRead.pressure, 2);
